### PR TITLE
fix: update Support Tickets to show email addresses instead of UUIDs

### DIFF
--- a/app/admin/components/TicketsTab.tsx
+++ b/app/admin/components/TicketsTab.tsx
@@ -12,8 +12,14 @@ interface SupportTicket {
   created_at: string
 }
 
-export default function TicketsTab({ tickets, getPriorityClass, getStatusClass, onOpen }: {
+interface User {
+  id: string
+  email: string
+}
+
+export default function TicketsTab({ tickets, users, getPriorityClass, getStatusClass, onOpen }: {
   tickets: SupportTicket[]
+  users: User[]
   getPriorityClass: (p: string) => string
   getStatusClass: (s: string) => string
   onOpen: (ticket: SupportTicket) => void
@@ -45,7 +51,14 @@ export default function TicketsTab({ tickets, getPriorityClass, getStatusClass, 
               tickets.map((ticket) => (
                 <tr key={ticket.id} className="bg-white border-b hover:bg-gray-50">
                   <td className="px-6 py-4 font-medium text-gray-900">#{ticket.id}</td>
-                  <td className="px-6 py-4"><div className="text-sm text-gray-900">{ticket.user_id}</div></td>
+                  <td className="px-6 py-4">
+                    <div className="text-sm text-gray-900">
+                      {(() => {
+                        const user = users.find(u => u.id === ticket.user_id)
+                        return user ? user.email : ticket.user_id
+                      })()}
+                    </div>
+                  </td>
                   <td className="px-6 py-4"><div className="max-w-xs truncate" title={ticket.subject}>{ticket.subject}</div></td>
                   <td className="px-6 py-4"><span className={`px-2 py-1 text-xs font-medium rounded-full ${getPriorityClass(ticket.priority)}`}>{ticket.priority}</span></td>
                   <td className="px-6 py-4"><span className={`px-2 py-1 text-xs font-medium rounded-full ${getStatusClass(ticket.status)}`}>{ticket.status}</span></td>

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -616,15 +616,7 @@ export default function AdminPage() {
                 Create Custom Program
               </button>
             )}
-            {activeTab === 'tickets' && (
-              <button
-                onClick={() => fetchSupportTickets()}
-                className="flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg shadow hover:bg-purple-700 transition"
-              >
-                <Headset size={18} />
-                Refresh Support Tickets
-              </button>
-            )}
+
           </div>
         </div>
 
@@ -706,6 +698,7 @@ export default function AdminPage() {
         {activeTab === 'tickets' && (
           <TicketsTab
             tickets={supportTickets as any}
+            users={users as any}
             getPriorityClass={(p) => p === 'urgent' ? 'bg-red-100 text-red-800' : p === 'high' ? 'bg-orange-100 text-orange-800' : p === 'normal' ? 'bg-blue-100 text-blue-800' : 'bg-gray-100 text-gray-800'}
             getStatusClass={(s) => s === 'open' ? 'bg-red-100 text-red-800' : s === 'in_progress' ? 'bg-yellow-100 text-yellow-800' : s === 'resolved' ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'}
             onOpen={openTicketModal as any}


### PR DESCRIPTION
- Remove duplicate refresh button from Support Tickets section
- Update TicketsTab component to accept users data
- Display user email addresses in Support Tickets table instead of UUIDs
- Improve readability of Support Tickets tab